### PR TITLE
Add Equation Converter plugin at end of list

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -14369,6 +14369,14 @@
 		"author": "Yunfi",
 		"description": "Upload images in a note, and remove the images from the vault if they're exclusively used within that note.",
 		"repo": "yy4382/obsidian-image-upload"
-  }
+  },
+	{
+    "id": "equation-converter",
+    "name": "Equation Converter",
+    "author": "Nyimbi Odero",
+    "description": "Converts OpenAI-style equation markup to standard markdown equation syntax",
+    "repo": "nyimbi/obsidian-equation-converter",
+    "branch": "main"
+}
 ]
 


### PR DESCRIPTION
This plugin converts OpenAI-style equation markup (\[ \] and \( \)) to standard markdown equation syntax ($$ $$ and $ $). Features:

- Converts inline equations from \(equation\) to $equation$
- Converts display equations from \[equation\] to $$ equation $$
- Preserves proper spacing and formatting
- Works on active file via ribbon icon or command palette
- Handles escaped delimiters correctly

Tested with Obsidian v0.15.0 and above
Repository: https://github.com/nyimbi/obsidian-equation-converter

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)
